### PR TITLE
Fix report.maec-1.1.xml typo in utils/api.py

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -246,7 +246,7 @@ def tasks_report(task_id, report_format="json"):
     formats = {
         "json": "report.json",
         "html": "report.html",
-        "maec": "report.maec-1.1.xml",
+        "maec": "report.maec-4.1.xml",
         "metadata": "report.metadata.xml",
     }
 


### PR DESCRIPTION
Noticed this typo while trying to access the MAEC report from the Cuckoo REST API.