### PR TITLE
Add API endpoint to retrieve MAEC-5.0 reports 

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -260,6 +260,7 @@ def tasks_report(task_id, report_format="json"):
     formats = {
         "json": "report.json",
         "html": "report.html",
+        "maec": "report.MAEC-5.0.json",
     }
 
     bz_formats = {
@@ -306,7 +307,7 @@ def tasks_report(task_id, report_format="json"):
         return json_error(400, "Invalid report format")
 
     if os.path.exists(report_path):
-        if report_format == "json":
+        if report_format == "json" or report_format == "maec":
             response = make_response(open(report_path, "rb").read())
             response.headers["Content-Type"] = "application/json"
             return response


### PR DESCRIPTION
Add `maec` as valid report format at API endpoint `/tasks/report/<int:task_id>/<report_format>`.

Essentially re-add functionality from this [commit (fe59c6f)](https://github.com/cuckoosandbox/cuckoo/commit/fe59c6fd532c60f8a970a2b4d4e03988ed8362a4).

I am open to changing the report format from `maec` to something that includes a MAEC version number (e.g., `maec5`), but I think it will be rare that a Cuckoo instance will be generating multiple MAEC reports with different versions.